### PR TITLE
show suboptimal moves after the fact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ config/
 **/*.pyc
 **/*.egg-info
 dist/
+tags
+tags.temp

--- a/blockfish-client/src/controller.rs
+++ b/blockfish-client/src/controller.rs
@@ -17,8 +17,10 @@ pub struct Controller<'v> {
     view: View<'v>,
     stacker: Stacker,
     progress: Progress,
-    undo_list: Vec<(Stacker, Progress)>,
+    undo_list: Vec<(Stacker, Progress, Option<Analysis>)>,
     analysis: Option<Analysis>,
+    prior_best_move: Option<Analysis>,
+    engine_visible: bool,
     trie: Option<Trie>,
 }
 
@@ -47,6 +49,8 @@ impl<'v> Controller<'v> {
             undo_list: Vec::with_capacity(100),
             progress: Progress::new(),
             analysis: None,
+            prior_best_move: None,
+            engine_visible: true,
         };
 
         ctl.consult_engine();
@@ -76,12 +80,19 @@ impl<'v> Controller<'v> {
                 self.progress.lines,
                 self.progress.color_clears,
                 self.progress.downstack,
+                self.progress.undo_hints,
                 self.stacker.config().garbage.total_lines,
             );
         }
         if upd.contains(Update::AI) {
-            if let Some(an) = self.analysis.as_mut() {
+            if let Some(an) = self.prior_best_move.as_mut() {
                 an.update_view(&mut self.view)
+            } else if let Some(an) = self.analysis.as_mut() {
+                if self.engine_visible {
+                    an.update_view(&mut self.view)
+                } else {
+                    self.view.set_engine_disabled();
+                }
             } else {
                 self.view.set_engine_disabled();
             }
@@ -117,7 +128,13 @@ impl<'v> Controller<'v> {
     pub fn poll_engine(&mut self) {
         let mut upd = Update::empty();
         if let Some(an) = self.analysis.as_mut() {
-            upd.set(Update::AI, an.poll());
+            upd.set(
+                Update::AI,
+                matches!(
+                    an.poll(),
+                    AnalysisStatus::Finished | AnalysisStatus::MovesUpdated
+                ),
+            );
             if let Some(trie) = self.trie.as_mut() {
                 upd.set(Update::TRIE, trie.poll());
             }
@@ -129,14 +146,20 @@ impl<'v> Controller<'v> {
     fn undo_save(&mut self) {
         let stacker = self.stacker.clone();
         let progress = self.progress.clone();
-        self.undo_list.push((stacker, progress));
+        let prior_best_move = self.prior_best_move.as_ref().map(Analysis::clone_as_best);
+        self.undo_list.push((stacker, progress, prior_best_move));
     }
 
     /// Restore the current state from the undo list.
     fn undo_restore(&mut self) {
-        let (stacker, progress) = self.undo_list.pop().expect("undo list cannot be empty!");
+        let (stacker, progress, prior_best_move) =
+            self.undo_list.pop().expect("undo list cannot be empty!");
         self.stacker = stacker;
         self.progress = progress;
+        if self.prior_best_move.is_some() {
+            self.progress.undo_hints += 1;
+        }
+        self.prior_best_move = prior_best_move;
     }
 
     /// Hard drops the current piece and updates `progress` as a result.
@@ -175,8 +198,25 @@ impl<'v> Controller<'v> {
             }
             GameOp::HardDrop => {
                 self.undo_save();
+                self.prior_best_move = None;
                 self.hard_drop();
                 upd.set(Update::STACKER, true);
+                if !self.engine_visible {
+                    loop {
+                        let Some(an) = self.analysis.as_mut() else {
+                            break;
+                        };
+                        if let AnalysisStatus::Finished = an.poll() {
+                            break;
+                        }
+                    }
+                    if let Some(an) = self.analysis.take() {
+                        let prior_best_move = an.clone_as_best();
+                        self.prior_best_move =
+                            Self::evaluate_selected_move(&self.stacker, prior_best_move);
+                        self.analysis = Some(an);
+                    }
+                }
             }
             GameOp::Reset => {
                 let ruleset = self.stacker.ruleset().clone();
@@ -185,6 +225,7 @@ impl<'v> Controller<'v> {
                 self.stacker = Stacker::new(ruleset, cfg);
                 self.progress = Progress::new();
                 self.undo_list.clear();
+                self.prior_best_move = None;
                 self.undo_save();
                 upd.set(Update::STACKER, true);
             }
@@ -204,6 +245,55 @@ impl<'v> Controller<'v> {
         }
 
         self.update_view(upd);
+    }
+
+    /// compares the selected move against the suggestions
+    fn evaluate_selected_move(
+        stacker: &Stacker,
+        mut prior_best_move: Analysis,
+    ) -> Option<Analysis> {
+        // get the best move from the analysis
+        let best_rating = prior_best_move.moves.first().unwrap().rating;
+        let actual_board = stacker.snapshot().unwrap();
+
+        for _ in 0..prior_best_move.moves.len() {
+            let mv = &prior_best_move.moves[prior_best_move.sel_idx];
+            let mut next_suggestion = stacker.clone();
+
+            const SUGGESTION_THRESHOLD: i64 = 50;
+            if prior_best_move.go_to(&mut next_suggestion) {
+                next_suggestion.hard_drop();
+                let next_suggestion = next_suggestion.snapshot()?;
+
+                if next_suggestion == actual_board {
+                    let actual_score = mv.rating;
+
+                    // print the difference in rating
+                    if actual_score == best_rating {
+                        log::info!("good move");
+                        return None;
+                    } else if actual_score - best_rating > SUGGESTION_THRESHOLD {
+                        log::info!("actual_score - best_rating: {}", actual_score - best_rating);
+                        prior_best_move.sel_idx = 0;
+                        for m in &mut prior_best_move.moves {
+                            m.rating -= actual_score;
+                        }
+                        prior_best_move.nav(0, 0);
+                        return Some(prior_best_move);
+                    } else {
+                        log::info!("good enough");
+                        return None;
+                    }
+                } else {
+                    prior_best_move.nav(1, 0);
+                }
+            }
+        }
+
+        // oof, not even on the list of suggestions
+        log::info!("oof");
+        prior_best_move.nav(0, 0);
+        return Some(prior_best_move);
     }
 
     /// Handles an engine related user action.
@@ -230,9 +320,17 @@ impl<'v> Controller<'v> {
                 upd.set(Update::ENGINE, true);
                 self.disable_engine();
             }
+            EngineOp::ToggleVisibility => {
+                upd.set(Update::ENGINE, true);
+                self.engine_visible = !self.engine_visible;
+                self.analysis = Some(an);
+            }
             EngineOp::Next | EngineOp::Prev => {
                 let delta = if op == EngineOp::Prev { -1 } else { 1 };
                 upd.set(Update::AI, an.nav(delta, 0));
+                if let Some(an) = &mut self.prior_best_move {
+                    upd.set(Update::AI, an.nav(delta, 0));
+                }
                 self.analysis = Some(an);
             }
             EngineOp::StepForward | EngineOp::StepBackward => {
@@ -314,6 +412,7 @@ struct Progress {
     lines: usize,
     downstack: usize,
     color_clears: usize,
+    undo_hints: usize,
 }
 
 impl Progress {
@@ -325,6 +424,7 @@ impl Progress {
             lines: 0,
             downstack: 0,
             color_clears: 0,
+            undo_hints: 0,
         }
     }
 
@@ -361,11 +461,35 @@ struct Analysis {
     sel_pos: usize,
 }
 
+impl Analysis {
+    fn clone_as_best(&self) -> Self {
+        let mut an = Self {
+            analysis: None,
+            status: self.status.clone(),
+            src: self.src.clone(),
+            preview: self.preview.clone(),
+            moves: self.moves.clone(),
+            sel_idx: 0,
+            sel_pos: 0,
+        };
+        assert!(an.nav(0, 0));
+        an
+    }
+}
+
 /// A move suggested by the analysis.
+#[derive(Clone)]
 struct Move {
     id: ai::MoveId,
     rating: i64,
     inputs: Vec<blockfish::Input>,
+}
+
+#[derive(Debug)]
+enum AnalysisStatus {
+    MovesUpdated,
+    NoChange,
+    Finished,
 }
 
 impl Analysis {
@@ -390,10 +514,10 @@ impl Analysis {
 
     /// Polls the background analysis for updates. Returns `true` if anything changed as a
     /// result of new analysis results.
-    fn poll(&mut self) -> bool {
+    fn poll(&mut self) -> AnalysisStatus {
         let mut an = match self.analysis.take() {
             Some(an) => an,
-            None => return false,
+            None => return AnalysisStatus::Finished,
         };
         let mut updated = false;
         for _ in 0..MAX_POLLS_PER_FRAME {
@@ -415,12 +539,16 @@ impl Analysis {
                         (time, nodes, iters)
                     });
                     // early return ends analysis
-                    return true;
+                    return AnalysisStatus::Finished;
                 }
             }
         }
         self.analysis = Some(an);
-        updated
+        if updated {
+            AnalysisStatus::MovesUpdated
+        } else {
+            AnalysisStatus::NoChange
+        }
     }
 
     /// Updates the stored moves by bringing move `m_id` up to date according to

--- a/blockfish-client/src/controls.rs
+++ b/blockfish-client/src/controls.rs
@@ -42,6 +42,7 @@ impl GameOp {
 #[allow(dead_code)]
 pub enum EngineOp {
     Toggle,
+    ToggleVisibility,
     Next,
     Prev,
     StepForward,
@@ -225,6 +226,7 @@ struct GameControlsSpec {
 #[derive(Deserialize)]
 struct EngineControlsSpec {
     toggle: KeyStroke,
+    toggle_visibility: KeyStroke,
     next: KeyStroke,
     prev: KeyStroke,
     forward: KeyStroke,
@@ -245,6 +247,10 @@ impl ControlsSpec {
             (Action::Game(GameOp::Reset), self.game.reset),
             (Action::Game(GameOp::Undo), self.game.undo),
             (Action::Engine(EngineOp::Toggle), self.engine.toggle),
+            (
+                Action::Engine(EngineOp::ToggleVisibility),
+                self.engine.toggle_visibility,
+            ),
             (Action::Engine(EngineOp::Next), self.engine.next),
             (Action::Engine(EngineOp::Prev), self.engine.prev),
             (Action::Engine(EngineOp::StepForward), self.engine.forward),

--- a/blockfish-client/src/view.rs
+++ b/blockfish-client/src/view.rs
@@ -240,6 +240,7 @@ impl<'r> View<'r> {
         lc: usize,
         cc: usize,
         ds: usize,
+        undo_hints: usize,
         ds_goal: Option<usize>,
     ) {
         let mut pace = None;
@@ -267,6 +268,7 @@ impl<'r> View<'r> {
         self.stats[0].set(&format!("pieces:        {}", pc));
         self.stats[1].set(&format!("lines:         {}", lc));
         self.stats[2].set(&format!("color clears:  {}", cc));
+        self.stats[2].set(&format!("undo_hints:    {}", undo_hints));
         self.stats[3].set(&format!("dpp:           {}", maybe_f32(dpp, "?")));
         self.stats[4].set(&format!("100L pace:     {}", maybe(pace, "\u{221e}")));
         self.progress.0.set(&progress_label);

--- a/support/default-controls.json
+++ b/support/default-controls.json
@@ -12,6 +12,7 @@
     },
     "engine": {
         "toggle": "C-e",
+        "toggle_visibility": "g",
         "next": "tab",
         "prev": "C-tab",
         "forward": "C-f",


### PR DESCRIPTION
Hey, not sure if this repo is being maintained and you're interested in PRs but I figured I'd open one in case you'd want to merge it. No pressure, I'm happy to use this on my own fork.

My underlying motivation here is that I was struggling to understand the feedback loop for using Blockfish as a training tool. I felt like I'd either disable the engine and not know when I made a bad move (it feels inconvenient to go back, toggle engine on to figure out if I'd made a bad move and what the better move was, toggle engine off again, then make the move), or I'd end up leaving the engine on and rather mindlessly following along, which doesn't feel like it's engaging my brain very much.

To address this, I added a mode where the engine view is hidden except when the prior move you made diverges from one of the top score moves. In that case it will show the best prior move, with the ratings updated to show the difference between the selected move and the previously suggested move.

Demo of it in use:


![blockfish-rate-move-pr](https://github.com/user-attachments/assets/db07cac3-84ec-4830-b8b1-f952bb1cad95)

---

Other ideas I'm considering adding (especially if there's interest in merging them):

* improve handling for moves that aren't even in the suggestion list
  * I haven't really dug into how the search and evaluation algorithms work, but I expect that there's some sort of pruning going on given the variable length list of suggestions and I figure I could probably have the suggestions also save the moves that are rejected and the reason they were rejected, and when one of those moves are input also display said reason why it is a bad move instead of simply showing the list of best moves with their absolute scores.
* replay analysis
  * I'd love to save a history of the entire run (bonus points if it works with jstris's replay format so I can analyze real runs) and have it go through and evaluate all the moves I made and point out which were bad and why, as well as try to extract any trends such as skims I miss most frequently. Ideally the trends would be able to operate on data from multiple runs.